### PR TITLE
Build updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,5 +36,4 @@ version = versionNumber
 
 allprojects {
     group = groupId
-    version = versionNumber
 }

--- a/plugin-rust-agent/build.gradle.kts
+++ b/plugin-rust-agent/build.gradle.kts
@@ -8,6 +8,7 @@ val teamcityVersion = rootProject.extra["teamcityVersion"] as String
 teamcity {
     version = teamcityVersion
     agent {
+        archiveName = project.name
         descriptor = project.file("teamcity-plugin.xml")
     }
 }
@@ -23,14 +24,4 @@ dependencies {
 
 tasks.named<Test>("test") {
     useTestNG()
-}
-
-tasks.jar {
-    archiveVersion.convention(null as String?)
-    archiveVersion.set(null as String?)
-}
-
-tasks.named<Zip>("agentPlugin") {
-    archiveVersion.convention(null as String?)
-    archiveVersion.set(null as String?)
 }

--- a/plugin-rust-agent/build.gradle.kts
+++ b/plugin-rust-agent/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("kotlin")
-    id("com.github.rodm.teamcity-agent") version "1.3"
+    id("com.github.rodm.teamcity-agent") version "1.3.1"
 }
 
 val teamcityVersion = rootProject.extra["teamcityVersion"] as String

--- a/plugin-rust-common/build.gradle.kts
+++ b/plugin-rust-common/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins{
-    id("com.github.rodm.teamcity-common") version "1.3"
+    id("com.github.rodm.teamcity-common") version "1.3.1"
     id("kotlin")
 }
 

--- a/plugin-rust-common/build.gradle.kts
+++ b/plugin-rust-common/build.gradle.kts
@@ -11,8 +11,3 @@ teamcity {
     version = rootProject.extra["teamcityVersion"] as String
 }
 
-tasks.jar {
-    archiveVersion.convention(null as String?)
-    archiveVersion.set(null as String?)
-}
-

--- a/plugin-rust-server/build.gradle.kts
+++ b/plugin-rust-server/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm")
-    id("com.github.rodm.teamcity-server") version "1.3"
-    id("com.github.rodm.teamcity-environments") version "1.3"
+    id("com.github.rodm.teamcity-server") version "1.3.1"
+    id("com.github.rodm.teamcity-environments") version "1.3.1"
 }
 
 val teamcityVersion = rootProject.extra["teamcityVersion"] as String

--- a/plugin-rust-server/build.gradle.kts
+++ b/plugin-rust-server/build.gradle.kts
@@ -10,6 +10,7 @@ teamcity {
     version = teamcityVersion
 
     server {
+        archiveName = "teamcity-rust-plugin"
         descriptor = project.file("teamcity-plugin.xml")
         tokens = mapOf("Plugin_Version" to "project.version")
     }
@@ -41,15 +42,4 @@ dependencies {
 
 tasks.named<Test>("test") {
     useTestNG()
-}
-
-tasks.jar {
-    archiveVersion.convention(null as String?)
-    archiveVersion.set(null as String?)
-}
-
-tasks.named<Zip>("serverPlugin") {
-    archiveVersion.convention(null as String?)
-    archiveVersion.set(null as String?)
-    archiveBaseName.set("teamcity-rust-plugin")
 }


### PR DESCRIPTION
These changes update the Gradle TeamCity plugin and simplify how the various archives are named.
Rather than setting the version property of the sub-projects and overridding the jar and zip tasks leaving it unset removes it from the archive names. For the agent and server plugin archives, this is set using the `archiveName` property.