### PR TITLE
Correct replacement of version token

### DIFF
--- a/plugin-rust-server/build.gradle.kts
+++ b/plugin-rust-server/build.gradle.kts
@@ -12,7 +12,7 @@ teamcity {
     server {
         archiveName = "teamcity-rust-plugin"
         descriptor = project.file("teamcity-plugin.xml")
-        tokens = mapOf("Plugin_Version" to "project.version")
+        tokens = mapOf("Plugin_Version" to rootProject.version)
     }
 
     environments {


### PR DESCRIPTION
The version token in the plugin descriptor was being replaced with the string 'project.version' this PR corrects the replacement. It uses the version property from the root project as it is no longer set for sub-projects.