### PR TITLE
Supporting common `--config` options in Cargo commands

### DIFF
--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/ArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/ArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -8,6 +8,7 @@
 package jetbrains.buildServer.rust
 
 import jetbrains.buildServer.agent.BuildRunnerContext
+import jetbrains.buildServer.util.StringUtil
 
 /**
  * Provides arguments to the utility.
@@ -15,4 +16,19 @@ import jetbrains.buildServer.agent.BuildRunnerContext
 interface ArgumentsProvider {
     fun getArguments(runnerContext: BuildRunnerContext): List<String>
     fun shouldFailBuildIfCommandFailed(): Boolean = true
+
+    fun addCommonArguments(parameters: Map<String, String>, arguments: MutableList<String>) {
+        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
+        if (!verbosityValue.isNullOrBlank()) {
+            arguments += verbosityValue.trim()
+        }
+
+        val configValue = parameters[CargoConstants.PARAM_CONFIG]
+        if (!configValue.isNullOrBlank()) {
+            StringUtil.splitCommandArgumentsAndUnquote(configValue).forEach { value ->
+                arguments += "--config"
+                arguments += value
+            }
+        }
+    }
 }

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/BenchArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/BenchArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -77,10 +77,7 @@ class BenchArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         val argumentsValue = parameters[CargoConstants.PARAM_BENCH_ARGUMENTS]
         if (!argumentsValue.isNullOrBlank()) {

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/BuildArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/BuildArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -71,10 +71,7 @@ class BuildArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         return arguments
     }

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/CleanArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/CleanArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -45,10 +45,7 @@ class CleanArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         return arguments
     }

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/DocArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/DocArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -67,10 +67,7 @@ class DocArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         return arguments
     }

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/LoginArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/LoginArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -28,10 +28,7 @@ class LoginArgumentsProvider : ArgumentsProvider {
             arguments.add(hostValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         val tokenValue = parameters[CargoConstants.PARAM_LOGIN_TOKEN_SECURE] ?: parameters[CargoConstants.PARAM_LOGIN_TOKEN]
         if (!tokenValue.isNullOrBlank()) {

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/PackageArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/PackageArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -38,10 +38,7 @@ class PackageArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         return arguments
     }

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/PublishArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/PublishArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -45,10 +45,7 @@ class PublishArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         return arguments
     }

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/RunArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/RunArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -66,10 +66,7 @@ class RunArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         val argumentsValue = parameters[CargoConstants.PARAM_RUN_ARGUMENTS]
         if (!argumentsValue.isNullOrBlank()) {

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/RustDocArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/RustDocArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -72,10 +72,7 @@ class RustDocArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         val optionsValue = parameters[CargoConstants.PARAM_RUSTDOC_OPTS]
         if (!optionsValue.isNullOrBlank()) {

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/RustcArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/RustcArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -72,10 +72,7 @@ class RustcArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         val optionsValue = parameters[CargoConstants.PARAM_RUSTC_OPTS]
         if (!optionsValue.isNullOrBlank()) {

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/TestArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/TestArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -82,10 +82,7 @@ class TestArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         val argumentsValue = parameters[CargoConstants.PARAM_TEST_ARGUMENTS]
         if (!argumentsValue.isNullOrBlank()) {

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/UpdateArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/UpdateArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -45,10 +45,7 @@ class UpdateArgumentsProvider : ArgumentsProvider {
             arguments.add(manifestValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         return arguments
     }

--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/YankArgumentsProvider.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/cargo/YankArgumentsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -45,10 +45,7 @@ class YankArgumentsProvider : ArgumentsProvider {
             arguments.add(tokenValue.trim())
         }
 
-        val verbosityValue = parameters[CargoConstants.PARAM_VERBOSITY]
-        if (!verbosityValue.isNullOrBlank()) {
-            arguments.add(verbosityValue.trim())
-        }
+        addCommonArguments(parameters, arguments)
 
         val crateValue = parameters[CargoConstants.PARAM_YANK_CRATE]
         if (!crateValue.isNullOrBlank()) {

--- a/plugin-rust-agent/src/test/kotlin/jetbrains/buildServer/rust/test/CargoRunnerBuildServiceTest.kt
+++ b/plugin-rust-agent/src/test/kotlin/jetbrains/buildServer/rust/test/CargoRunnerBuildServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -167,7 +167,10 @@ class CargoRunnerBuildServiceTest {
 
                 arrayOf(CollectionsUtil.asMap(
                         CargoConstants.PARAM_BUILD_TARGET, "name",
-                        CargoConstants.PARAM_BUILD_MANIFEST, "/path/to/manifest"), listOf("build", "--target", "name", "--manifest-path", "/path/to/manifest")))
+                        CargoConstants.PARAM_BUILD_MANIFEST, "/path/to/manifest"), listOf("build", "--target", "name", "--manifest-path", "/path/to/manifest")),
+
+                arrayOf(mapOf(CargoConstants.PARAM_CONFIG to "simple=\"value\" complex=[\"value\",\"another value\"]"),
+                        listOf("build", "--config", "simple=\"value\"", "--config", "complex=[\"value\",\"another value\"]")))
     }
 
     @DataProvider(name = "testCleanArgumentsData")

--- a/plugin-rust-common/src/main/kotlin/jetbrains/buildServer/rust/CargoConstants.kt
+++ b/plugin-rust-common/src/main/kotlin/jetbrains/buildServer/rust/CargoConstants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -45,6 +45,7 @@ object CargoConstants {
 
     const val PARAM_COMMAND = "cargo-command"
     const val PARAM_VERBOSITY = "cargo-verbosity"
+    const val PARAM_CONFIG = "cargo-config"
     const val PARAM_TOOLCHAIN = "cargo-toolchain"
 
     const val PARAM_BUILD_PACKAGE = "cargo-build-package"

--- a/plugin-rust-server/kotlin-dsl/CargoStep.xml
+++ b/plugin-rust-server/kotlin-dsl/CargoStep.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2000-2021 JetBrains s.r.o.
+  ~ Copyright 2000-2023 JetBrains s.r.o.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License").
   ~ See LICENSE in the project root for license information.
@@ -630,15 +630,23 @@
                 </param>
             </option>
         </param>
+
         <param name="cargo-verbosity" dslName="verbosity" type="Verbosity">
             <description>
                 Specify Cargo output verbosity
                 @see Verbosity
             </description>
         </param>
+
         <param name="cargo-toolchain" dslName="toolchain">
             <description>
                 Toolchain version
+            </description>
+        </param>
+
+        <param name="cargo-config" dslName="config">
+            <description>
+                Space-separated list of Cargo configuration options in KEY=VALUE format.
             </description>
         </param>
 

--- a/plugin-rust-server/src/main/kotlin/jetbrains/buildServer/rust/CargoParametersProvider.kt
+++ b/plugin-rust-server/src/main/kotlin/jetbrains/buildServer/rust/CargoParametersProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 JetBrains s.r.o.
+ * Copyright 2000-2023 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * See LICENSE in the project root for license information.
@@ -10,7 +10,6 @@ package jetbrains.buildServer.rust
 import jetbrains.buildServer.controllers.BasePropertiesBean
 import jetbrains.buildServer.rust.commands.CommandType
 import jetbrains.buildServer.rust.commands.cargo.*
-import jetbrains.buildServer.util.StringUtil
 
 /**
  * Provides parameters for cargo runner.
@@ -39,6 +38,9 @@ class CargoParametersProvider {
 
     val verbosityKey: String
         get() = CargoConstants.PARAM_VERBOSITY
+
+    val configKey: String
+        get() = CargoConstants.PARAM_CONFIG
 
     val toolchainKey: String
         get() = CargoConstants.PARAM_TOOLCHAIN

--- a/plugin-rust-server/src/main/resources/buildServerResources/editCargoParameters.jsp
+++ b/plugin-rust-server/src/main/resources/buildServerResources/editCargoParameters.jsp
@@ -3,10 +3,10 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="bs" tagdir="/WEB-INF/tags" %>
 <%--
-  ~ Copyright 2000-2021 JetBrains s.r.o.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ See LICENSE in the project root for license information.
+  - Copyright 2000-2023 JetBrains s.r.o.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License").
+  - See LICENSE in the project root for license information.
   --%>
 
 <jsp:useBean id="propertiesBean" scope="request" type="jetbrains.buildServer.controllers.BasePropertiesBean"/>
@@ -31,6 +31,16 @@
             <props:option value="--verbose">Verbose</props:option>
             <props:option value="--quiet">Quiet</props:option>
         </props:selectProperty>
+    </td>
+</tr>
+
+<tr class="advancedSetting">
+    <th><label for="${params.configKey}">Configuration options:</label></th>
+    <td>
+        <props:textProperty name="${params.configKey}" className="longField"/>
+        <span class="smallNote">
+            Space-separated list of Cargo configuration options in KEY=VALUE format.
+        </span>
     </td>
 </tr>
 

--- a/plugin-rust-server/src/main/resources/buildServerResources/viewCargoParameters.jsp
+++ b/plugin-rust-server/src/main/resources/buildServerResources/viewCargoParameters.jsp
@@ -1,10 +1,10 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
 <%--
-  ~ Copyright 2000-2021 JetBrains s.r.o.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ See LICENSE in the project root for license information.
+  - Copyright 2000-2023 JetBrains s.r.o.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License").
+  - See LICENSE in the project root for license information.
   --%>
 
 <jsp:useBean id="propertiesBean" scope="request" type="jetbrains.buildServer.controllers.BasePropertiesBean"/>
@@ -24,6 +24,12 @@
 <c:if test="${not empty propertiesBean.properties[params.verbosityKey]}">
     <div class="parameter">
         Output verbosity: <props:displayValue name="${params.verbosityKey}"/>
+    </div>
+</c:if>
+
+<c:if test="${not empty propertiesBean.properties[params.configKey]}">
+    <div class="parameter">
+        Configuration options: <props:displayValue name="${params.configKey}"/>
     </div>
 </c:if>
 


### PR DESCRIPTION
Like the verbosity setting, the `--config` option is supported by all Cargo commands and is a practical alternative to environment variables.