### PR TITLE
making produced commands Windows-compatible

### DIFF
--- a/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/CargoCommandBuildSession.kt
+++ b/plugin-rust-agent/src/main/kotlin/jetbrains/buildServer/rust/CargoCommandBuildSession.kt
@@ -7,6 +7,7 @@ import jetbrains.buildServer.agent.inspections.InspectionReporter
 import jetbrains.buildServer.agent.runner.*
 import jetbrains.buildServer.rust.inspections.ClippyInspectionsParser
 import jetbrains.buildServer.util.FileUtil
+import jetbrains.buildServer.util.OSType
 import java.io.File
 import java.util.*
 import java.util.concurrent.atomic.AtomicReference
@@ -26,7 +27,6 @@ class CargoCommandBuildSession(
 
     private var buildSteps: Iterator<CommandExecution>? = null
     private val executionResult: AtomicReference<BuildFinishedStatus> = AtomicReference(BuildFinishedStatus.FINISHED_SUCCESS)
-    private var lastCommands = arrayListOf<CommandExecution>()
     private val filesToClean = mutableListOf<File>()
 
     override fun sessionStarted() {
@@ -48,21 +48,20 @@ class CargoCommandBuildSession(
         return executionResult.get()
     }
 
-    private fun getSteps() = iterator {
+    private fun getSteps(): Iterator<CommandExecution> = iterator {
         runnerContext.runnerParameters[CargoConstants.PARAM_TOOLCHAIN]?.let {
             if (it.isNotBlank()) {
                 val installToolchain = RustupToolchainBuildService("install")
-                yield(addCommand(installToolchain))
+                yield(createCommand(installToolchain))
 
-                // Rustup could fail to install toolchain
-                // We could try to resolve it by execution uninstall of toolchain
-                // and cleaning up temporary directories
+                // `Rustup` could fail to install a toolchain.
+                // We can try to resolve it by uninstalling the toolchain and cleaning up temporary directories.
                 if (installToolchain.errors.isNotEmpty()) {
                     val logger = runnerContext.build.buildLogger
                     logger.message("Installation has failed, will remove toolchain '${installToolchain.version}' and try again")
 
                     val uninstallToolchain = RustupToolchainBuildService("uninstall")
-                    yield(addCommand(uninstallToolchain))
+                    yield(createCommand(uninstallToolchain))
 
                     val rustupCache = RustupToolProvider.getHome()
                     installToolchain.version.let { toolchainVersion ->
@@ -75,7 +74,7 @@ class CargoCommandBuildSession(
                         FileUtil.delete(File(rustupCache, "${CargoConstants.RUSTUP_HASHES_DIR}/$toolchainVersion"))
                     }
 
-                    yield(addCommand(RustupToolchainBuildService("install")))
+                    yield(createCommand(RustupToolchainBuildService("install")))
                 }
             }
         }
@@ -93,18 +92,16 @@ class CargoCommandBuildSession(
 
         commands.add(createCommand(CargoRunnerBuildService(runnerContext, inspectionReporter, clippyInspectionsParser), true))
 
-        val command = MultiCommandExecution(commands, runnerContext.workingDirectory, filesToClean)
-        lastCommands.add(command)
-        yield(command)
+        if (runnerContext.isVirtualContext) {
+            yield(MultiCommandExecution(commands, runnerContext, filesToClean))
+        } else {
+            commands.forEach { command -> yield(command) }
+        }
     }
 
     private fun createCommand(buildService: CommandLineBuildService, redirectStderrToStdout: Boolean = false) = CommandExecutionAdapter(buildService.apply {
         this.initialize(runnerContext.build, runnerContext)
     }, redirectStderrToStdout, executionResult)
-
-    private fun addCommand(buildService: CommandLineBuildService, redirectStderrToStdout: Boolean = false) = createCommand(buildService, redirectStderrToStdout).apply {
-        lastCommands.add(this)
-    }
 
     private fun cleanFiles() {
         filesToClean.forEach {
@@ -117,17 +114,13 @@ class CargoCommandBuildSession(
     }
 }
 
-class MultiCommandExecution(
+private class MultiCommandExecution(
     private val commands: List<CommandExecution>,
-    private val workingDirectory: File,
+    private val runnerContext: BuildRunnerContextEx,
     private val filesToClean: MutableList<File>
 ) : CommandExecution {
-
-    override fun makeProgramCommandLine(): ProgramCommandLine = MultiProgramCommandLine(
-        commands.map { it.makeProgramCommandLine() },
-        workingDirectory,
-        filesToClean
-    )
+    override fun makeProgramCommandLine(): ProgramCommandLine =
+        MultiProgramCommandLine(commands.map { it.makeProgramCommandLine() }, runnerContext, filesToClean)
     override fun onStandardOutput(text: String) = last { it.onStandardOutput(text) }
     override fun onErrorOutput(text: String) = last { it.onErrorOutput(text) }
     override fun processStarted(programCommandLine: String, workingDirectory: File) =
@@ -148,29 +141,31 @@ class MultiCommandExecution(
         return result
     }
     override fun isCommandLineLoggingEnabled(): Boolean = last { it.isCommandLineLoggingEnabled }
-    private fun <T> last(block: (CommandExecution) -> T): T {
-        return block(commands.last())
-    }
+    private fun <T> last(block: (CommandExecution) -> T): T = block(commands.last())
 }
 
-class MultiProgramCommandLine(
+private class MultiProgramCommandLine(
     private val commands: List<ProgramCommandLine>,
-    private val workingDirectory: File,
+    private val runnerContext: BuildRunnerContextEx,
     private val filesToClean: MutableList<File>
 ) : ProgramCommandLine {
     override fun getExecutablePath(): String {
-        val script = File(workingDirectory, "multi-command-line-${UUID.randomUUID()}")
+        val script = File(runnerContext.workingDirectory, "multi-command-line-${UUID.randomUUID()}.cmd")
         val stream = script.outputStream().bufferedWriter()
         for (command in commands) {
             stream.appendLine("cd ${command.workingDirectory}")
-            stream.appendLine("${command.executablePath} \"${command.arguments.joinToString("\" \"")}\"")
+            val argumentLine = when (runnerContext.virtualContext.targetOSType) {
+                OSType.WINDOWS -> command.arguments.joinToString(" ")
+                else -> command.arguments.joinToString(separator = "\" \"", prefix = "\"", postfix = "\"")
+            }
+            stream.appendLine("${command.executablePath} $argumentLine")
         }
         stream.close()
         script.setExecutable(true)
         filesToClean.add(script)
         return script.absolutePath
     }
-    override fun getWorkingDirectory(): String = workingDirectory.absolutePath
+    override fun getWorkingDirectory(): String = runnerContext.workingDirectory.absolutePath
     override fun getArguments(): List<String> = emptyList()
     override fun getEnvironment(): Map<String, String> = commands.map { it.environment }.fold(emptyMap()) { m1, m2 -> m1 + m2 }
 }


### PR DESCRIPTION
First, `cmd.exe /c` arguments shouldn't be quoted. Next, a multi-command script must have a recognizable extension (Unix systems don't care, so `.cmd` suites all). Finally, there's no need to group commands when no container is targeted.

Bonus point: dropping an unused `CargoCommandBuildSession#lastCommands` collection.